### PR TITLE
Move [super updateConstraints] to the end

### DIFF
--- a/2013-08-07-advanced-auto-layout-toolbox.md
+++ b/2013-08-07-advanced-auto-layout-toolbox.md
@@ -127,8 +127,8 @@ You could also decide to change the constraints after the first layout pass. For
     
     - updateConstraints
     {
-        [super updateConstraints];
         // add constraints depended on self.layoutRows...
+        [super updateConstraints];
     }
 
 


### PR DESCRIPTION
In accordance with the documentation. [iOS cite](https://developer.apple.com/library/ios/documentation/uikit/reference/uiview_class/uiview/uiview.html#//apple_ref/occ/instm/UIView/updateConstraints) and [OS X cite](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSView_Class/Reference/NSView.html#//apple_ref/occ/instm/NSView/updateConstraints).

There's also a related outstanding issue [over here](https://github.com/objcio/issue-3-auto-layout-debugging/issues/2).
