### PR TITLE
Update 2014-03-07-icloud-core-data.md

### DIFF
--- a/2014-03-07-icloud-core-data.md
+++ b/2014-03-07-icloud-core-data.md
@@ -77,7 +77,7 @@ While Apple hasn’t released official sample code for iCloud Core Data in iOS 7
         return @{NSPersistentStoreUbiquitousContentNameKey: @"MyAppStore"};
     }
     
-    - (void) persistentStoreDidImportUbiquitousContentChanges:(NSNotification *)notification {
+    - (void) persistentStoreDidImportUbiquitousContentChanges:(NSNotification *)changeNotification {
         NSManagedObjectContext *context = self.managedObjectContext;
     	
         [context performBlock:^{


### PR DESCRIPTION
In the method, a different name for the passed notification was used
