### PR TITLE
s/cancelation/cancellation/g

### DIFF
--- a/2013-07-07-concurrency-apis-and-pitfalls.md
+++ b/2013-07-07-concurrency-apis-and-pitfalls.md
@@ -212,7 +212,7 @@ If you want more control and to maybe execute an asynchronous task within the op
 
 Notice that in this case, you have to manage the operation's state manually. In order for an operation queue to be able to pick up a such a change, the state properties have to be implemented in a KVO-compliant way. So make sure to send proper KVO messages in case you don't set them via default accessor methods.
 
-In order to benefit from the cancelation feature exposed by operation queues, you should regularly check the `isCancelled` property for longer-running operations:
+In order to benefit from the cancellation feature exposed by operation queues, you should regularly check the `isCancelled` property for longer-running operations:
 
     - (void)main
     {


### PR DESCRIPTION
Spelling of "cancelation" is rarely used outside of the U.S., and is
inconsistent with the `-isCancelled` method in the same sentence. Change
to "cancellation", with two l's.

---

Sorry if this is too trivial! :sweat_smile: 
