### PR TITLE
Changed object type for hourHand and minuteHand.

### DIFF
--- a/2014-05-08-animating-custom-layer-properties.md
+++ b/2014-05-08-animating-custom-layer-properties.md
@@ -38,8 +38,8 @@ To demonstrate this approach, let's create a simple analog clock where we can se
     @interface ClockFace ()
 
     //private properties
-    @property (nonatomic, strong) CALayer *hourHand;
-    @property (nonatomic, strong) CALayer *minuteHand;
+    @property (nonatomic, strong) CAShapeLayer *hourHand;
+    @property (nonatomic, strong) CAShapeLayer *minuteHand;
 
     @end
 


### PR DESCRIPTION
Changed object type for hourHand and minuteHand properties from CALayer to CAShapeLayer.
hourHand and minuteHand are declared as CALayer but created as CAShapeLayer.
Even more CALayer doesn't have "path" property, which is used further.
