### PR TITLE
Changed strong to weak for IBOutlet datePicker

### DIFF
--- a/2014-05-08-animating-custom-layer-properties.md
+++ b/2014-05-08-animating-custom-layer-properties.md
@@ -76,7 +76,7 @@ We'll also set up a basic view controller with a `UIDatePicker` so we can test o
 
     @interface ViewController ()
 
-    @property (nonatomic, strong) IBOutlet UIDatePicker *datePicker;
+    @property (nonatomic, weak) IBOutlet UIDatePicker *datePicker;
     @property (nonatomic, strong) ClockFace *clockFace;
 
     @end


### PR DESCRIPTION
Reference to object created in nib file should be weak.
