### PR TITLE
Various fixes to the Travis article scripts

### DIFF
--- a/2013-11-08-travis-ci.markdown
+++ b/2013-11-08-travis-ci.markdown
@@ -176,8 +176,9 @@ Now we have to make sure that the certificates get imported in the Travis CI key
 	security import ./scripts/certs/apple.cer -k ~/Library/Keychains/ios-build.keychain -T /usr/bin/codesign
 	security import ./scripts/certs/dist.cer -k ~/Library/Keychains/ios-build.keychain -T /usr/bin/codesign
 	security import ./scripts/certs/dist.p12 -k ~/Library/Keychains/ios-build.keychain -P $KEY_PASSWORD -T /usr/bin/codesign
+	security default-keychain -s ios-build.keychain
 	mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-	cp ./scripts/profile/$PROFILE_NAME.mobileprovision ~/Library/MobileDevice/Provisioning\ Profiles/
+	cp "./scripts/profile/$PROFILE_NAME.mobileprovision" ~/Library/MobileDevice/Provisioning\ Profiles/
 
 Here we create a new temporary keychain called `ios-build` that will contain all the certificates. Note that we use the `$KEY_PASSWORD` here to import the private key. As a final step, the mobile provisioning profile is copied into the `Library` folder.
 
@@ -202,7 +203,7 @@ If you run this command, you should find the app binary in the `build/Release-ip
 	PROVISIONING_PROFILE="$HOME/Library/MobileDevice/Provisioning Profiles/$PROFILE_NAME.mobileprovision"
 	OUTPUTDIR="$PWD/build/Release-iphoneos"
 
-	xcrun -log -sdk iphoneos PackageApplication "$OUTPUTDIR/$APPNAME.app" -o "$OUTPUTDIR/$APPNAME.ipa" -sign "$DEVELOPER_NAME" -embed "$PROVISIONING_PROFILE"
+	xcrun -log -sdk iphoneos PackageApplication "$OUTPUTDIR/$APP_NAME.app" -o "$OUTPUTDIR/$APP_NAME.ipa" -sign "$DEVELOPER_NAME" -embed "$PROVISIONING_PROFILE"
 
 Lines two through nine are quite important. You don't want to create a new release while working on a feature branch. The same is true for pull requests. Builds for pull requests wouldn't work anyway, as secured environment variables [are disabled](http://about.travis-ci.org/docs/user/build-configuration/#Secure-environment-variables).
 
@@ -212,7 +213,7 @@ The last script will remove the temporary keychain again and delete the mobile p
 
 	#!/bin/sh
 	security delete-keychain ios-build.keychain
-	rm -f ~/Library/MobileDevice/Provisioning\ Profiles/$PROFILE_NAME.mobileprovision
+	rm -f "~/Library/MobileDevice/Provisioning Profiles/$PROFILE_NAME.mobileprovision"
 
 As a last step, we have to tell Travis when to execute these three scripts. The keys should be added before the app is built and the signing and cleanup should happen afterwards. Add/replace the following steps in your `.travis.yml`:
 
@@ -249,8 +250,8 @@ Create a [TestFlight account](https://testflightapp.com/register/) and set up yo
 Now we can call the API accordingly. Add this to the `sign-and-build.sh`:
 
 	curl http://testflightapp.com/api/builds.json \
-	  -F file="@$OUTPUTDIR/$APPNAME.ipa" \
-	  -F dsym="@$OUTPUTDIR/$APPNAME.app.dSYM.zip" \
+	  -F file="@$OUTPUTDIR/$APP_NAME.ipa" \
+	  -F dsym="@$OUTPUTDIR/$APP_NAME.app.dSYM.zip" \
 	  -F api_token="$TESTFLIGHT_API_TOKEN" \
 	  -F team_token="$TESTFLIGHT_TEAM_TOKEN" \
 	  -F distribution_lists='Internal' \
@@ -274,8 +275,8 @@ Then call their API from the `sign-and-build.sh` script:
 	  -F notify="0" \
 	  -F notes="$RELEASE_NOTES" \
 	  -F notes_type="0" \
-	  -F ipa="@$OUTPUTDIR/$APPNAME.ipa" \
-	  -F dsym="@$OUTPUTDIR/$APPNAME.app.dSYM.zip" \
+	  -F ipa="@$OUTPUTDIR/$APP_NAME.ipa" \
+	  -F dsym="@$OUTPUTDIR/$APP_NAME.app.dSYM.zip" \
 	  -H "X-HockeyAppToken: $HOCKEY_APP_TOKEN"
 
 Note that we also upload the `dsym` file. If you integrate the [TestFlight](https://testflightapp.com/sdk/ios/doc/) or [HockeyApp SDK](http://hockeyapp.net/releases/), you can get human-readable crash reports without further ado.


### PR DESCRIPTION
Found and fixed some problems in the Travis article scripts:
- Creating a keychain but not setting it as default so xctool will use it for signing
- Using sometimes $APP_NAME and sometimes $APPNAME
- Spaces in $PROFILE_NAME were causing problems
