### PR TITLE
Another travis script fix

### DIFF
--- a/2013-11-08-travis-ci.markdown
+++ b/2013-11-08-travis-ci.markdown
@@ -172,15 +172,27 @@ With that, your files on GitHub will be secured, while Travis can still read and
 Now we have to make sure that the certificates get imported in the Travis CI keychain. To do this, we should add a new file, `add-key.sh`, in the `scripts` folder:
 
 	#!/bin/sh
+	
+	# Create a custom keychain
 	security create-keychain -p travis ios-build.keychain
+	
+	# Set keychain timeout to 1 hour for long builds
+	# see http://www.egeek.me/2013/02/23/jenkins-and-xcode-user-interaction-is-not-allowed/
+	security set-keychain-settings -t 3600 -l ~/Library/Keychains/ios-build.keychain
+	
+	# Add certificates to keychain and allow codesign to access them
 	security import ./scripts/certs/apple.cer -k ~/Library/Keychains/ios-build.keychain -T /usr/bin/codesign
 	security import ./scripts/certs/dist.cer -k ~/Library/Keychains/ios-build.keychain -T /usr/bin/codesign
 	security import ./scripts/certs/dist.p12 -k ~/Library/Keychains/ios-build.keychain -P $KEY_PASSWORD -T /usr/bin/codesign
+	
+	# Make the custom keychain default, so xcodebuild will use it for signing
 	security default-keychain -s ios-build.keychain
+	
+	# Put the provisioning profile in place
 	mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
 	cp "./scripts/profile/$PROFILE_NAME.mobileprovision" ~/Library/MobileDevice/Provisioning\ Profiles/
 
-Here we create a new temporary keychain called `ios-build` that will contain all the certificates. Note that we use the `$KEY_PASSWORD` here to import the private key. As a final step, the mobile provisioning profile is copied into the `Library` folder.
+Here we create a new temporary keychain called `ios-build` that will contain all the certificates, and make sure it's ready to be used for codesigning. Note that we use the `$KEY_PASSWORD` here to import the private key. As a final step, the mobile provisioning profile is copied into the `Library` folder.
 
 After creating this file, make sure to give it executable rights. On the command line, type `chmod a+x scripts/add-key.sh`. You have to do this for the following scripts as well.
 


### PR DESCRIPTION
I spent hours debugging an annoying keychain problem, which turned out to be a default timeout of 5 minutes set by default on the use of the keychain.
See http://www.egeek.me/2013/02/23/jenkins-and-xcode-user-interaction-is-not-allowed/ for more info.

Also added comments to the script to increase readability.
