### PR TITLE
Update 2014-05-08-animations-explained.md

### DIFF
--- a/2014-05-08-animations-explained.md
+++ b/2014-05-08-animations-explained.md
@@ -145,7 +145,7 @@ Setting the `keyTimes` property allows us to specify at which point in time the 
 
 [^2]: Note how I chose different values for transitions from 0 to 30 and from 30 to -30 to maintain a constant velocity.
 
-Setting the `additive` property to `YES` tells Core Animation to add the values of the animation to the value of the model layer, before updating the presentation layer. This allows us to reuse the same animation for all form elements that need updating without having to know their positions in advance. Since this property is inherited from `CAPropertyAnimation`, you can also make use of it when employing `CABasicAnimation`.
+Setting the `additive` property to `YES` tells Core Animation to add the values of the animation to the value of the current presentation layer. This allows us to reuse the same animation for all form elements that need updating without having to know their positions in advance. Since this property is inherited from `CAPropertyAnimation`, you can also make use of it when employing `CABasicAnimation`.
 
 ## Animation Along a Path
 


### PR DESCRIPTION
"Setting the additive property to YES tells Core Animation to add the values of the animation to the value of the model layer, before updating the presentation layer"

```
CAKeyframeAnimation *animation = [CAKeyframeAnimation animation];
animation.keyPath = @"position.x";
animation.values = @[ @0, @10, @-10, @10, @0 ];
animation.keyTimes = @[ @0, @(1 / 6.0), @(3 / 6.0), @(5 / 6.0), @1 ];
animation.duration = 0.4;

animation.additive = YES;

[form.layer addAnimation:animation forKey:@"shake"];
```

above code doesn't change the value of model layer. I think it would be better if we write something like 

"Setting the additive property to YES tells Core Animation to add the values of the animation to the value of the current presentation layer"
