### PR TITLE
Remove extra word from the Swift functions article

### DIFF
--- a/2014-09-10-swift-functions.md
+++ b/2014-09-10-swift-functions.md
@@ -307,7 +307,7 @@ public struct JSValue : Equatable {
 ```
 
 ## Fancy Parameters
-Compared to Objective-C, Swift has a lot of extra options for what type of parameters can be passed in. Here are some of examples. 
+Compared to Objective-C, Swift has a lot of extra options for what type of parameters can be passed in. Here are some examples. 
 
 ### Optional Parameter Types
 


### PR DESCRIPTION
Just a minor fix.
