### PR TITLE
Fix code workers typo.

### DIFF
--- a/2013-11-08-build-process.md
+++ b/2013-11-08-build-process.md
@@ -145,7 +145,7 @@ Another nice use of a custom build phase is to watermark your app icon with the 
 
 After that, you can modify the app icon using ImageMagick. For a complete example of how to do this, check out [this GitHub project](https://github.com/krzysztofzablocki/IconOverlaying).
 
-If you'd like to encourage yourself or your code workers to keep your source files concise, you can add a "Run Script" build phase that spits out a warning if a source file exceeds a certain size, in this example 200 lines.
+If you'd like to encourage yourself or your co-workers to keep your source files concise, you can add a "Run Script" build phase that spits out a warning if a source file exceeds a certain size, in this example 200 lines.
 
     find "${SRCROOT}" \( -name "*.h" -or -name "*.m" \) -print0 | xargs -0 wc -l | awk '$1 > 200 && $2 != "total" { print $2 ":1: warning: file more than 200 lines" }'
 


### PR DESCRIPTION
Code workers is more amusing. Ignore this if you like that better.

It is not clear if you prefer co-worker or coworker. The hyphenated form is used in 2014-08-11-snapshot-testing and 2014-09-10-swift-functions, and the other form in 2014-08-11-bad-testing-practices.
