### PR TITLE
Snippet fixed.

### DIFF
--- a/2013-07-07-low-level-concurrency-apis.md
+++ b/2013-07-07-low-level-concurrency-apis.md
@@ -474,7 +474,6 @@ Here we're setting up a timer to fire every 5 seconds and allow for a leeway of 
     dispatch_source_set_event_handler(source, ^(){
         NSLog(@"Time flies.");
     });
-    dispatch_time_t start
     dispatch_source_set_timer(source, DISPATCH_TIME_NOW, 5ull * NSEC_PER_SEC, 
       100ull * NSEC_PER_MSEC);
     self.source = source;


### PR DESCRIPTION
Snippet for dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, DISPATCH_TARGET_QUEUE_DEFAULT) fixed.
Definitely, you changed your mind while writing this.