### PR TITLE
Fix __weak keywork position mistake.

### DIFF
--- a/2013-07-07-low-level-concurrency-apis.md
+++ b/2013-07-07-low-level-concurrency-apis.md
@@ -728,7 +728,7 @@ Here's an example for OSSpinLock:
     - (NSDictionary *)amountAttributes;
     {
         if (_amountAttributes == nil) {
-            static __weak NSDictionary *cachedAttributes = nil;
+            static NSDictionary * __weak cachedAttributes = nil;
             static OSSpinLock lock = OS_SPINLOCK_INIT;
             OSSpinLockLock(&lock);
             _amountAttributes = cachedAttributes;


### PR DESCRIPTION
Based on Apple's doc: [Transitioning to ARC Release Notes][ARCNote], `__weak` is type qualifier. So, the correct position of `__weak` is `Type * __weak weakPtr`, which is weakPtr is a weak pointer points to a variable with Type, instant of `__weak Type * notWeakPtr`, which is notWeakPtr is a pointer points to a weak variable with Type.

Since `const` is type qualifier too, replacing `__weak` by `const` is a easy way to verify it. The following is the example to show the difference: `Type * const constPtr`and `const Type * ptrToConstType`.

[ARCNote]:[https://developer.apple.com/library/ios/releasenotes/ObjectiveC/RN-TransitioningToARC/Introduction/Introduction.html]