### PR TITLE
Updated the NSDateFormatter sample code.

### DIFF
--- a/2014-10-10-receipt-validation.md
+++ b/2014-10-10-receipt-validation.md
@@ -252,6 +252,7 @@ NSDate *expirationDate = nil;
 
 // Date formatter to handle RFC 3339 dates in GMT time zone
 NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+[formatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
 [formatter setDateFormat:@"yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'"];
 [formatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
 


### PR DESCRIPTION
Fixed bug where receipt dates would not parse when the system language was set to Hebrew (or possibly other languages).